### PR TITLE
Adapt library so that it distinguishes between numeral and number.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,11 @@
 Python-radix library
 ====================
 
-The library contains tools for conversion numbers to a new base. Current version works with radixes from 2 to 36.
+The library contains tools for representing natural numbers in a given base,
+or to current any numeral representing a natural number between two bases.
+Currently any base between 2 and 36 is supported.
+
+
 
 Python-radix usage examples
 ---------------------------
@@ -11,28 +15,40 @@ Python-radix has both procedural and object-oriented solutions.
 
 **Procedural way example**
 
-    # to convert number 4 from base 10 to base 2
+    # to convert numeral 4 in base 10 to base 2
 
-    cast(4, 10, 2)
+    cast('4', 10, 2)
 
     >>'100'
 
-You can use both str and int types for the number you convert.
+    # to convert the integer 4 to base 2
+    cast(4, None, 2)
+
+    Note that since the first argument is a number, rather than a numeral,
+    the second parameter is irrelevant, so None is used.
 
 **Object oriented way example**
 
-    # create an object to convert numbers from one base to another (here it converts from base 10 to base 2)
+    # create an object to find the base 2 representation of any natural number
 
-    new = Converter(10, 2)
+    new = Converter(None, 2)
 
     new.convert(4)
 
     >>'100'
 
-This will work too:
+    # create an object to find the base 2 representation of any base 10 numeral
 
     new = Converter(10, 2)
 
     new.convert('4')
 
     >>'100'
+
+**Using characters as digits**
+
+    # the digits 0 through 9 are succeeded by the lower case ASCII alphabet
+
+    cast('a', 16, 10)
+
+    >> '10'

--- a/anyradix/anyradix.py
+++ b/anyradix/anyradix.py
@@ -1,37 +1,47 @@
 symbol = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
 
-def to_base_10(number, old_base):
+max_base = len(symbol)
+
+def numeral_to_number(number, old_base):
+    """
+    Convert str number in old_base to an int value.
+    """
     result = 0
-    figures = str(number).lower()[::-1]
-    for index, elem in enumerate(figures):
+    for elem in number.lower():
         if elem not in symbol:
-            raise Exception('Not valid number')
+            raise Exception('Not valid number.')
         i = symbol.index(elem)
         if i >= old_base:
-            raise Exception('Not valid number')
-        result += i * old_base**index
-    return str(result)
+            raise Exception('Not valid number.')
+        result = result * old_base + i
+    return result
 
-def from_base_10(number, new_base):
+def number_to_numeral(number, new_base):
+    """
+    Convert int number to str in new_base.
+    """
     result = ''
-    try:
-        number = int(number)
-    except:
-        raise Exception('Not valid number')
     while number > 0:
         remainder = number % new_base
         result = symbol[remainder] + result
-        number = number/new_base
+        number = number // new_base
     return result
 
 def cast(number, old_base, new_base):
-    if old_base==1 or new_base==1:
-        raise Exception('Not valid base')
-    if old_base != 10:
-        number = to_base_10(number, old_base)
-    if new_base != 10:
-        number = from_base_10(number, new_base)
-    return number
+    if new_base < 2 or new_base > max_base:
+        raise Exception('Not a valid base.')
+
+    if isinstance(number, str):
+        if old_base < 2 or old_base > max_base:
+            raise Exception('Not a valid base.')
+        number = numeral_to_number(number, old_base)
+    elif isinstance(number, int):
+        if old_base is not None:
+            raise Exception('Second argument should be None.')
+    else:
+        raise Exception("Not a valid number.")
+
+    return number_to_numeral(number, new_base)
 
 
 class Converter:
@@ -39,5 +49,4 @@ class Converter:
         self.old_base = old_base
         self.new_base = new_base
     def convert(self, number):
-        result = cast(number, self.old_base, self.new_base)
-        return result
+        return cast(number, self.old_base, self.new_base)

--- a/tests/Testing.py
+++ b/tests/Testing.py
@@ -1,38 +1,44 @@
 import unittest
 from anyradix import *
-from anyradix.anyradix import to_base_10
-from anyradix.anyradix import from_base_10
 from timeit import timeit
 
 class TestRadixPerformance(unittest.TestCase):
     def test_perf(self):
         def testtime():
             for i in range(1000):
-                cast(i, 16, 32)
+                cast(str(i), 16, 32)
         timeit(testtime, number=1000)
 
 class TestRadixMethods(unittest.TestCase):
 
     def test_to_base_10(self):
-        self.assertEqual(to_base_10('cfa7291', 25), '3080188976')
+        self.assertEqual(numeral_to_number('cfa7291', 25), 3080188976)
 
     def test_from_base_10(self):
-        self.assertEqual(from_base_10('1465324', 15), '1de284')
+        self.assertEqual(number_to_numeral(1465324, 15), '1de284')
 
     def test_cast(self):
         self.assertEqual(cast('51330od', 26, 36), 'privet')
+        self.assertEqual(cast('privet', 36, 26), '51330od')
+        self.assertEqual(cast(24, None, 12), '20')
 
     def test_from_base_10_exception(self):
         with self.assertRaises(Exception):
-            from_base_10('a453', 12)
+            number_to_numeral('a453', 12)
 
     def test_to_base_10_exception(self):
         with self.assertRaises(Exception):
-            to_base_10('a453', 9)
+            numeral_to_number('a453', 9)
 
     def test_cast_exception(self):
         with self.assertRaises(Exception):
             cast('9453', 9, 5)
+        with self.assertRaises(Exception):
+            cast('9453', 10, 100)
+
+    def test_converter(self):
+        self.assertEqual(Converter(4, 2).convert('3'), cast('3', 4, 2))
+        self.assertEqual(Converter(None, 2).convert(3), cast(3, None, 2))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also:
Adapt README.rst to match and add a remark about character digits.

Compute the value of a numeral more efficiently in numeral_to_number.

Use Python 3 '//' in case this is used in Python 3.

Check for base that exceed maximum allowed.

Adapt some tests appropriately, and add a few more.

Signed-off-by: mulhern mulhern@cs.wisc.edu
